### PR TITLE
IMAccountValidatorHandler.cpp: Fix compatibility with new DB8 API cal…

### DIFF
--- a/src/IMAccountValidatorHandler.cpp
+++ b/src/IMAccountValidatorHandler.cpp
@@ -67,8 +67,8 @@ MojErr IMAccountValidatorHandler::init(IMAccountValidatorApp* const app)
 	MojLogTrace(IMAccountValidatorApp::s_log);
 	MojLogInfo(IMAccountValidatorApp::s_log, IMVersionString);
 
-    // Add the methods publicly
-	MojErr err = addMethods(s_methods, true);
+    // Add the methods
+	MojErr err = addMethods(s_methods);
 	MojErrCheck(err);
 
 	// set up signed-on, signed-off callback pointers - see LibpurpleAdapter::assignIMLoginState


### PR DESCRIPTION
…l from OSE

OSE has dropped the API call with the 2nd parameter as per https://github.com/webosose/db8/commit/d6276fe1f86d6484ed1c086e86e993fdb2da0935, therefore changing it.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>