### PR TITLE
imaccountvalidator: Set proper ACG permissions

### DIFF
--- a/files/sysbus/com.palm.imaccountvalidator.api.json
+++ b/files/sysbus/com.palm.imaccountvalidator.api.json
@@ -1,5 +1,12 @@
 {
-    "private": [
+    "applications": [
+        "com.palm.imaccountvalidator/validateAccount",
+        "com.palm.imaccountvalidator/getEvent",
+        "com.palm.imaccountvalidator/getOptions",
+        "com.palm.imaccountvalidator/answerEvent",
+        "com.palm.imaccountvalidator/logout"
+    ],
+    "services": [
         "com.palm.imaccountvalidator/validateAccount",
         "com.palm.imaccountvalidator/getEvent",
         "com.palm.imaccountvalidator/getOptions",


### PR DESCRIPTION
Get rid of "private" group.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>