### PR TITLE
com.palm.imaccountvalidator: Migrate to Enhanced ACG

### DIFF
--- a/files/sysbus/com.palm.imaccountvalidator.api.json
+++ b/files/sysbus/com.palm.imaccountvalidator.api.json
@@ -1,12 +1,5 @@
 {
-    "applications": [
-        "com.palm.imaccountvalidator/validateAccount",
-        "com.palm.imaccountvalidator/getEvent",
-        "com.palm.imaccountvalidator/getOptions",
-        "com.palm.imaccountvalidator/answerEvent",
-        "com.palm.imaccountvalidator/logout"
-    ],
-    "services": [
+    "imaccountvalidator.operation": [
         "com.palm.imaccountvalidator/validateAccount",
         "com.palm.imaccountvalidator/getEvent",
         "com.palm.imaccountvalidator/getOptions",

--- a/files/sysbus/com.palm.imaccountvalidator.perm.json
+++ b/files/sysbus/com.palm.imaccountvalidator.perm.json
@@ -1,5 +1,5 @@
 {
     "com.palm.imaccountvalidator": [
-        "services"
+        "imaccountvalidator.operation"
     ]
 }

--- a/files/sysbus/com.palm.imaccountvalidator.role.json.in
+++ b/files/sysbus/com.palm.imaccountvalidator.role.json.in
@@ -1,5 +1,6 @@
 {
     "exeName":"@WEBOS_INSTALL_SBINDIR@/imaccountvalidator",
+    "trustLevel": "oem",
     "type": "regular",
     "allowedNames": ["com.palm.imaccountvalidator"],
     "permissions": [


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
